### PR TITLE
When there's no one to call us (us)

### DIFF
--- a/.gas-snapshot
+++ b/.gas-snapshot
@@ -1,1 +1,1 @@
-MoraleTest:testPurchase() (gas: 131940)
+MoraleTest:testPurchase() (gas: 133484)

--- a/src/BigStepper.sol
+++ b/src/BigStepper.sol
@@ -6,7 +6,7 @@ import "solmate/tokens/ERC721.sol";
 import "./MrMorale.sol";
 
 contract BigStepper {
-    constructor(MrMorale morale, ERC721 token, uint256 id) {
-        token.transferFrom(address(this), morale.buyoooor(), id);
+    constructor(MrMorale morale, address selloooor, ERC721 token, uint256 id) {
+        token.transferFrom(selloooor, morale.buyoooor(), id);
     }
 }

--- a/src/Enoch.sol
+++ b/src/Enoch.sol
@@ -26,8 +26,8 @@ contract Enoch {
                 abi.encodePacked(
                     bytes1(0xFF),
                     address(morale),
-                    keccak256(abi.encode(price, selloooor)),
-                    keccak256(abi.encodePacked(type(BigStepper).creationCode, abi.encode(morale, token, id)))
+                    keccak256(abi.encode(price)),
+                    keccak256(abi.encodePacked(type(BigStepper).creationCode, abi.encode(morale, selloooor, token, id)))
                 )
             )
         );

--- a/src/MrMorale.sol
+++ b/src/MrMorale.sol
@@ -12,8 +12,9 @@ contract MrMorale {
         payable(selloooor).transfer(price);
 
         buyoooor = msg.sender;
-        new BigStepper{salt: keccak256(abi.encode(price, selloooor))}(
+        new BigStepper{salt: keccak256(abi.encode(price))}(
             this,
+            selloooor,
             token,
             id
         );
@@ -22,10 +23,15 @@ contract MrMorale {
         // gg no re.
     }
 
-    function delist(ERC721 token, uint256 id, uint256 price) public {
+    // Normally, to delist you can simply revoke approval from the stepper.
+    // However in case you have some sort of public permit approval to the
+    // stepper that you have no way to revoke, you can use this function to
+    // transfer the token to yourself and brick the stepper contract forever.
+    function brick(ERC721 token, uint256 id, uint256 price) public {
         buyoooor = msg.sender;
-        new BigStepper{salt: keccak256(abi.encode(price, msg.sender))}(
+        new BigStepper{salt: keccak256(abi.encode(price))}(
             this,
+            msg.sender,
             token,
             id
         );

--- a/test/Morale.t.sol
+++ b/test/Morale.t.sol
@@ -38,8 +38,9 @@ contract MoraleTest is Test {
         address stepper = enoch.findStepper(morale, erc721A, id, price, addr1);
 
         vm.prank(addr1);
-        erc721A.transferFrom(addr1, stepper, id);
-        assertEq(erc721A.ownerOf(id), stepper);
+        erc721A.approve(stepper, id);
+        assertEq(erc721A.ownerOf(id), addr1);
+        assertEq(erc721A.getApproved(id), stepper);
 
         uint256 balanceBefore = addr1.balance;
 
@@ -51,5 +52,6 @@ contract MoraleTest is Test {
         assertEq(balanceBefore, balanceAfter - price);
 
         assertEq(erc721A.ownerOf(id), addr2);
+        assertEq(erc721A.getApproved(id), address(0));
     }
 }


### PR DESCRIPTION
This PR enables users to keep listed NFTs in their wallet until the point of sale, by having `BigStepper`s transfer from the sellers instead of themselves. This requires introducing an extra constructor argument to `BigStepper`: the seller. 

From my understanding this has no impact on morale's blacklist evasion properties and has very little impact on its security guarantees. Compared to a standard marketplace, it has one downside: requiring a separate approval to the respective `BigStepper` for each listing. However, this is not a concern for tokens with permit, and will eventually be mitigated for most tokens via Permit2. Regardless, it is at least neutral with our previous approach here which required a transfer for each listing anyway.

Only other thing to be aware of is the delist function has been removed, in favor of having users simply revoke their approvals from `BigStepper`s when they wish to delist. However, if approvals are performed via public permit signatures, users can ensure they are not taken advantage of by using the `brick` function, which allows the seller to purchase the NFT from themselves for free, bricking the `BigStepper` from being used again in the future and effectively forcibly delisting the token.